### PR TITLE
Added support for empty secondary key list when querying

### DIFF
--- a/internal/store/indexes/index.go
+++ b/internal/store/indexes/index.go
@@ -3,8 +3,9 @@ package indexes
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 	"math"
+
+	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 )
 
 // maxKeyLength defines the index key maximum length in bytes

--- a/internal/store/indexes/index_test.go
+++ b/internal/store/indexes/index_test.go
@@ -2,10 +2,11 @@ package indexes
 
 import (
 	"errors"
-	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 )
 
 func Test_encodeDecodeIndexKey(t *testing.T) {

--- a/internal/store/indexes/main_test.go
+++ b/internal/store/indexes/main_test.go
@@ -1,9 +1,10 @@
 package indexes
 
 import (
-	"github.com/iov-one/cosmos-sdk-crud/internal/test"
 	"os"
 	"testing"
+
+	"github.com/iov-one/cosmos-sdk-crud/internal/test"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/store/indexes/store_test.go
+++ b/internal/store/indexes/store_test.go
@@ -3,9 +3,10 @@ package indexes
 import (
 	"bytes"
 	"errors"
+	"testing"
+
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 	"github.com/iov-one/cosmos-sdk-crud/internal/test"
-	"testing"
 )
 
 func TestStore(t *testing.T) {

--- a/internal/store/objects/store.go
+++ b/internal/store/objects/store.go
@@ -2,6 +2,7 @@ package objects
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
@@ -12,23 +13,24 @@ import (
 func NewStore(cdc codec.Marshaler, db sdk.KVStore) Store {
 	ctr := Counter{}
 	return Store{
-		db:  db,
-		cdc: cdc,
+		db:      db,
+		cdc:     cdc,
 		objects: &ctr,
 	}
 }
+
 type Counter struct {
 	count uint64
 }
 
 // Store builds an object store
 type Store struct {
-	db     sdk.KVStore
-	cdc    codec.Marshaler
+	db  sdk.KVStore
+	cdc codec.Marshaler
 	// This has to be a reference in order to persist between calls
 	// Otherwise, if we want to use a simple uint64,
 	// we must switch to pointer receiver and pointer storage in struct (or use it through an interface)
-	objects* Counter
+	objects *Counter
 }
 
 // Create creates the object in the store

--- a/internal/store/objects/store.go
+++ b/internal/store/objects/store.go
@@ -2,10 +2,10 @@ package objects
 
 import (
 	"fmt"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
+	"github.com/iov-one/cosmos-sdk-crud/internal/util"
 )
 
 // NewStore is Store's constructor
@@ -18,26 +18,28 @@ func NewStore(cdc codec.Marshaler, db sdk.KVStore) Store {
 
 // Store builds an object store
 type Store struct {
-	db  sdk.KVStore
-	cdc codec.Marshaler
+	db     sdk.KVStore
+	cdc    codec.Marshaler
+	numObj uint64
 }
 
 // Create creates the object in the store
 // returns an error if it already exists
 // or if marshalling fails
-func (s Store) Create(o types.Object) error {
+func (s *Store) Create(o types.Object) error {
 	pk := o.PrimaryKey()
 	if s.db.Has(pk) {
 		return fmt.Errorf("%w: primary key %x", types.ErrAlreadyExists, pk)
 	}
 	err := s.set(pk, o)
+	s.numObj++
 	return err
 }
 
 // Store retrieves the object given its primary key
 // fails if it does not exist, or if unmarshalling fails
 // the types.Object must be a pointer
-func (s Store) Read(pk []byte, o types.Object) error {
+func (s *Store) Read(pk []byte, o types.Object) error {
 	b := s.db.Get(pk)
 	// if nil we assume it was not found
 	if b == nil {
@@ -52,7 +54,7 @@ func (s Store) Read(pk []byte, o types.Object) error {
 
 // Update updates the given object, fails if it does not exist
 // or if marshalling fails
-func (s Store) Update(o types.Object) error {
+func (s *Store) Update(o types.Object) error {
 	pk := o.PrimaryKey()
 	if !s.db.Has(pk) {
 		return fmt.Errorf("%w: primary key %x", types.ErrNotFound, pk)
@@ -66,17 +68,64 @@ func (s Store) Update(o types.Object) error {
 
 // Delete deletes an object given its primary key
 // fails if the object does not exist
-func (s Store) Delete(primaryKey []byte) error {
+func (s *Store) Delete(primaryKey []byte) error {
 	if !s.db.Has(primaryKey) {
 		return fmt.Errorf("%w: primary key %x", types.ErrNotFound, primaryKey)
 	}
 	s.db.Delete(primaryKey)
+	s.numObj--
 	return nil
+}
+
+// GetAllKeys returns a slice containing the primary key of all the objects present in the store
+// in the interval [start, end[ and in ascending order.
+// Returns an error if the iterator cannot be closed
+func (s *Store) GetAllKeys(start, end uint64) ([][]byte, error) {
+	// We could use append but it has to reallocate each time its capacity is reached
+	// Tracking the number of objects on the store is more efficient
+
+	// If the start offset is superior to the number of element, we can skip directly
+	if start >= s.numObj {
+		return make([][]byte, 0), nil
+	}
+
+	// The maximum size of the result set is the number of objects minus the start offset
+	var size = s.numObj - start
+	// If the range is finite, the actual size is the queried length, with a maximum of the previously computed length
+	if end != 0 {
+		size = util.Uint64Min(end-start, size)
+	}
+
+	keys := make([][]byte, size)
+	// The start and end arguments of Iterator() are not indexes but byte array boundaries
+	it := s.db.Iterator(nil, nil)
+	defer it.Close()
+
+	rng, err := util.NewRange(start, end)
+	if err != nil {
+		return make([][]byte, 0), err
+	}
+
+	var stopIter, inRange bool
+	for i := uint64(0); it.Valid() && !stopIter; it.Next() {
+		inRange, stopIter = rng.CheckAndMoveForward()
+		//TODO: this could be changed with juste inRange when merged with the new Range version
+		if inRange && !stopIter {
+			// This should never happen and is an internal error
+			if i >= size {
+				return make([][]byte, 0), types.ErrInternal
+			}
+
+			keys[i] = it.Key()
+			i++
+		}
+	}
+	return keys, nil
 }
 
 // set takes care of doing object marshalling
 // and setting it in the store
-func (s Store) set(key []byte, o codec.ProtoMarshaler) error {
+func (s *Store) set(key []byte, o codec.ProtoMarshaler) error {
 	b, err := s.cdc.MarshalBinaryLengthPrefixed(o)
 	if err != nil {
 		return err

--- a/internal/store/objects/store_test.go
+++ b/internal/store/objects/store_test.go
@@ -3,7 +3,6 @@ package objects
 import (
 	"bytes"
 	"errors"
-	"sort"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -165,17 +164,8 @@ func checkKeys(t *testing.T, actual [][]byte, objects []types.Object) {
 
 func createStoreWithRandomObjects(cdc codec.Marshaler, db sdk.KVStore, t *testing.T, n int, uniqueID string) (Store, []types.Object) {
 	store := NewStore(cdc, prefix.NewStore(db, []byte(uniqueID)))
-	var objs []types.Object = nil
-
-	for i := 0; i < n; i++ {
-		obj := test.NewRandomObject()
-		objs = append(objs, obj)
-		err := store.Create(obj)
-		if err != nil {
-			t.Fatal(err)
-		}
+	addToStore := func(obj types.Object) error {
+		return store.Create(obj)
 	}
-
-	sort.Slice(objs, func(i, j int) bool { return bytes.Compare(objs[i].PrimaryKey(), objs[j].PrimaryKey()) < 0 })
-	return store, objs
+	return store, test.CreateRandomObjects(addToStore, t, n)
 }

--- a/internal/store/objects/store_test.go
+++ b/internal/store/objects/store_test.go
@@ -3,11 +3,12 @@ package objects
 import (
 	"bytes"
 	"errors"
+	"sort"
+	"testing"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"sort"
-	"testing"
 
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 	"github.com/iov-one/cosmos-sdk-crud/internal/test"

--- a/internal/store/objects/store_test.go
+++ b/internal/store/objects/store_test.go
@@ -1,7 +1,12 @@
 package objects
 
 import (
+	"bytes"
 	"errors"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"sort"
 	"testing"
 
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
@@ -109,4 +114,67 @@ func TestStore(t *testing.T) {
 			t.Fatal("unexpected error", err)
 		}
 	})
+
+	t.Run("get all key", func(t *testing.T) {
+		store, objs := createStoreWithRandomObjects(cdc, db, t, 10, "allkey")
+
+		actual, err := store.GetAllKeys(0, 0)
+		if err != nil {
+			t.Fatal("Unexpected error :", err)
+		}
+		checkKeys(t, actual, objs)
+	})
+
+	t.Run("get key range", func(t *testing.T) {
+		store, objs := createStoreWithRandomObjects(cdc, db, t, 10, "keyrange")
+
+		//TODO: uncomment this test when merging with the newer version of Range
+		/*actual, err := store.GetAllKeys(5, 0)
+		if err != nil {
+			t.Fatal("Unexpected error :", err)
+		}
+		checkKeys(t, actual, objs[5:])*/
+
+		actual, err := store.GetAllKeys(5, 7)
+		if err != nil {
+			t.Fatal("Unexpected error :", err)
+		}
+		checkKeys(t, actual, objs[5:7])
+
+		actual, err = store.GetAllKeys(2, 12)
+		if err != nil {
+			t.Fatal("Unexpected error :", err)
+		}
+		checkKeys(t, actual, objs[2:])
+	})
+}
+
+func checkKeys(t *testing.T, actual [][]byte, objects []types.Object) {
+	if len(actual) != len(objects) {
+		t.Fatalf("Result set length mismatch : actual = %v, expected = %v", len(actual), len(objects))
+	}
+
+	for i := 0; i < len(actual); i++ {
+		expected := objects[i].PrimaryKey()
+		if !bytes.Equal(actual[i], expected) {
+			t.Fatalf("Invalid key at position %v : actual = %v, expected = %v", i, actual[i], expected)
+		}
+	}
+}
+
+func createStoreWithRandomObjects(cdc codec.Marshaler, db sdk.KVStore, t *testing.T, n int, uniqueID string) (Store, []types.Object) {
+	store := NewStore(cdc, prefix.NewStore(db, []byte(uniqueID)))
+	var objs []types.Object = nil
+
+	for i := 0; i < n; i++ {
+		obj := test.NewRandomObject()
+		objs = append(objs, obj)
+		err := store.Create(obj)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sort.Slice(objs, func(i, j int) bool { return bytes.Compare(objs[i].PrimaryKey(), objs[j].PrimaryKey()) < 0 })
+	return store, objs
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -121,7 +121,13 @@ func (s Store) RegisterObject(o types.Object) {
 }
 
 func (s Store) Query(sks []types.SecondaryKey, start, end uint64) (*Cursor, error) {
-	pks, err := s.indexes.Filter(sks, start, end)
+	var err error
+	var pks [][]byte
+	if len(sks) == 0 {
+		pks, err = s.objects.GetAllKeys(start, end)
+	} else {
+		pks, err = s.indexes.Filter(sks, start, end)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -98,12 +98,12 @@ func TestStore(t *testing.T) {
 			if i == len(objs) {
 				t.Fatalf("Length mismatch, exepected %v elements but got more", len(objs))
 			}
-			var actual types.Object
-			if err := results.Read(actual); err != nil {
+			var actual = test.NewObject()
+			if err := results.Read(*actual); err != nil {
 				t.Fatal("Unexpected error :", err)
 			}
-			if !reflect.DeepEqual(actual, objs[i]) {
-				t.Fatalf("Object mismatch at index %v : expected = %v, actual = %v", i, objs[i], actual)
+			if !reflect.DeepEqual(*actual, objs[i]) {
+				t.Fatalf("Object mismatch at index %v : expected = %v(%[2]T), actual = %v(%[3]T)", i, objs[i], actual)
 			}
 			i++
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,11 +3,12 @@ package store
 import (
 	"bytes"
 	"errors"
-	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 	"github.com/iov-one/cosmos-sdk-crud/internal/test"

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,7 +1,12 @@
 package store
 
 import (
+	"bytes"
 	"errors"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
@@ -79,4 +84,46 @@ func TestStore(t *testing.T) {
 	if !errors.Is(err, types.ErrNotFound) {
 		t.Fatal("unexpected error", err)
 	}
+
+	t.Run("query all", func(t *testing.T) {
+		s, objs := createStoreWithRandomObjects(cdc, db, t, 50, "queryall")
+
+		results, err := s.Query(nil, 0, 0)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		i := 0
+		for ; results.Valid(); results.Next() {
+			if i == len(objs) {
+				t.Fatalf("Length mismatch, exepected %v elements but got more", len(objs))
+			}
+			var actual types.Object
+			if err := results.Read(actual); err != nil {
+				t.Fatal("Unexpected error :", err)
+			}
+			if !reflect.DeepEqual(actual, objs[i]) {
+				t.Fatalf("Object mismatch at index %v : expected = %v, actual = %v", i, objs[i], actual)
+			}
+			i++
+		}
+
+	})
+}
+
+func createStoreWithRandomObjects(cdc codec.Marshaler, db sdk.KVStore, t *testing.T, n int, uniqueID string) (Store, []types.Object) {
+	store := NewStore(cdc, db, []byte(uniqueID))
+	var objs []types.Object = nil
+
+	for i := 0; i < n; i++ {
+		obj := test.NewRandomObject()
+		objs = append(objs, obj)
+		err := store.Create(obj)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sort.Slice(objs, func(i, j int) bool { return bytes.Compare(objs[i].PrimaryKey(), objs[j].PrimaryKey()) < 0 })
+	return store, objs
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,10 +1,8 @@
 package store
 
 import (
-	"bytes"
 	"errors"
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -114,17 +112,8 @@ func TestStore(t *testing.T) {
 
 func createStoreWithRandomObjects(cdc codec.Marshaler, db sdk.KVStore, t *testing.T, n int, uniqueID string) (Store, []types.Object) {
 	store := NewStore(cdc, db, []byte(uniqueID))
-	var objs []types.Object = nil
-
-	for i := 0; i < n; i++ {
-		obj := test.NewRandomObject()
-		objs = append(objs, obj)
-		err := store.Create(obj)
-		if err != nil {
-			t.Fatal(err)
-		}
+	addToStore := func(obj types.Object) error {
+		return store.Create(obj)
 	}
-
-	sort.Slice(objs, func(i, j int) bool { return bytes.Compare(objs[i].PrimaryKey(), objs[j].PrimaryKey()) < 0 })
-	return store, objs
+	return store, test.CreateRandomObjects(addToStore, t, n)
 }

--- a/internal/store/types/types.pb.go
+++ b/internal/store/types/types.pb.go
@@ -5,11 +5,12 @@ package types
 
 import (
 	fmt "fmt"
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/store/types/types_test.pb.go
+++ b/internal/store/types/types_test.pb.go
@@ -5,12 +5,13 @@ package types
 
 import (
 	fmt "fmt"
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
-	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/test/crud_test.go
+++ b/internal/test/crud_test.go
@@ -164,7 +164,7 @@ func Test_Starname(t *testing.T) {
 				t.Fatal("Unexpected error :", err)
 			}
 
-			if ! reflect.DeepEqual(actual, expected) {
+			if !reflect.DeepEqual(actual, expected) {
 				t.Fatalf("Starname mismatch, expected %v, got %v", expected, actual)
 			}
 			cursor.Next()

--- a/internal/test/crud_test.go
+++ b/internal/test/crud_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -146,6 +147,34 @@ func Test_Starname(t *testing.T) {
 	t.Run("success on primary key", func(t *testing.T) {
 		// TODO
 	})
+
+	t.Run("success on select all", func(t *testing.T) {
+		cursor, err := store.Query().Do()
+		if err != nil {
+			t.Fatal("Unexpected error :", err)
+		}
+
+		for i, expected := range starnames {
+			if !cursor.Valid() {
+				t.Fatal("got less than expected, expected length is", len(starnames), "data ended at index", i)
+			}
+
+			actual := NewTestStarname("", "", "")
+			if err := cursor.Read(actual); err != nil {
+				t.Fatal("Unexpected error :", err)
+			}
+
+			if ! reflect.DeepEqual(actual, expected) {
+				t.Fatalf("Starname mismatch, expected %v, got %v", expected, actual)
+			}
+			cursor.Next()
+		}
+
+		if cursor.Valid() {
+			t.Fatal("Got more results than expected")
+		}
+	})
+
 	t.Run("success on un-ranged owned accounts", func(t *testing.T) {
 		for _, owner := range owners {
 			cursor, err := store.Query().Where().Index(starnameOwnerIndex).Equals([]byte(owner)).Do()

--- a/internal/test/suite.go
+++ b/internal/test/suite.go
@@ -1,8 +1,11 @@
 package test
 
 import (
+	"bytes"
 	"crypto/rand"
 	"fmt"
+	"sort"
+	"testing"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -156,4 +159,20 @@ func (this *Object) Equals(that *Object) error {
 	}
 
 	return nil
+}
+
+func CreateRandomObjects(add func(types.Object) error, t *testing.T, n int) []types.Object {
+	var objs []types.Object = nil
+
+	for i := 0; i < n; i++ {
+		obj := NewRandomObject()
+		objs = append(objs, obj)
+		err := add(obj)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sort.Slice(objs, func(i, j int) bool { return bytes.Compare(objs[i].PrimaryKey(), objs[j].PrimaryKey()) < 0 })
+	return objs
 }

--- a/internal/util/math.go
+++ b/internal/util/math.go
@@ -1,0 +1,6 @@
+package util
+
+func Uint64Min(a, b uint64) uint64 {
+	if b < a { return b }
+	return a
+}

--- a/internal/util/math.go
+++ b/internal/util/math.go
@@ -1,6 +1,8 @@
 package util
 
 func Uint64Min(a, b uint64) uint64 {
-	if b < a { return b }
+	if b < a {
+		return b
+	}
 	return a
 }

--- a/query.go
+++ b/query.go
@@ -59,10 +59,6 @@ func (q *query) Do() (Cursor, error) {
 	if len(q.errs) != 0 {
 		return nil, q.errs[0]
 	}
-	// check if query has something to query
-	if len(q.sks) == 0 {
-		return nil, fmt.Errorf("%w: no secondary keys supplied to query", ErrBadArgument)
-	}
 	// check if query was already run
 	if q.consumed {
 		return nil, fmt.Errorf("%w: query already consumed", ErrBadArgument)

--- a/query.go
+++ b/query.go
@@ -2,6 +2,7 @@ package crud
 
 import (
 	"fmt"
+
 	"github.com/iov-one/cosmos-sdk-crud/internal/store"
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 )

--- a/query.go
+++ b/query.go
@@ -6,7 +6,13 @@ import (
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 )
 
+type ValidQuery interface {
+	WithRange() RangeStatement
+	Do() (Cursor, error)
+}
+
 type QueryStatement interface {
+	ValidQuery
 	Where() WhereStatement
 }
 
@@ -27,9 +33,8 @@ type RangeEndStatement interface {
 }
 
 type FinalizedIndexStatement interface {
+	ValidQuery
 	And() WhereStatement
-	WithRange() RangeStatement
-	Do() (Cursor, error)
 }
 
 func newQuery(s store.Store) *query {

--- a/query_test.go
+++ b/query_test.go
@@ -2,11 +2,12 @@ package crud
 
 import (
 	"errors"
+	"reflect"
+	"testing"
+
 	"github.com/iov-one/cosmos-sdk-crud/internal/store"
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
 	"github.com/iov-one/cosmos-sdk-crud/internal/test"
-	"reflect"
-	"testing"
 )
 
 func Test_query(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -66,7 +66,7 @@ func Test_query(t *testing.T) {
 	})
 
 	t.Run("success/no secondary keys", func(t *testing.T) {
-		q := newQuery(store.Store{})
+		q := newQuery(crudStore)
 		_, err := q.Do()
 		t.Logf("%s", err)
 		if err != nil {

--- a/query_test.go
+++ b/query_test.go
@@ -64,16 +64,18 @@ func Test_query(t *testing.T) {
 			t.Fatal("unexpected result")
 		}
 	})
-	t.Run("bad argument/already consumed", func(t *testing.T) {
-		_, _ = q.Do() // do it twice in case we run this subtest only!
+
+	t.Run("success/no secondary keys", func(t *testing.T) {
+		q := newQuery(store.Store{})
 		_, err := q.Do()
 		t.Logf("%s", err)
-		if !errors.Is(err, ErrBadArgument) {
+		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
-	t.Run("bad argument/no secondary keys", func(t *testing.T) {
-		q := newQuery(store.Store{})
+
+	t.Run("bad argument/already consumed", func(t *testing.T) {
+		_, _ = q.Do() // do it twice in case we run this subtest only!
 		_, err := q.Do()
 		t.Logf("%s", err)
 		if !errors.Is(err, ErrBadArgument) {


### PR DESCRIPTION
The `query` framework used to forbid queries without condition (that is, a secondary key list). This is now allowed and returns a list of all the objects present in the store.