### PR TITLE
Adds indexing and querying benchmarks

### DIFF
--- a/internal/store/indexes/store.go
+++ b/internal/store/indexes/store.go
@@ -76,7 +76,7 @@ func (s Store) Index(o types.Object) error {
 		if err != nil {
 			return err
 		}
-		// add the computed key obtained after registering it to the keys lsit
+		// add the computed key obtained after registering it to the keys list
 		keysList[i] = computedKey
 	}
 	// save indexes list


### PR DESCRIPTION
The benchmarks can be run using `go test ./... -bench '.*' -benchtime 10s` (the timing is adjustable but the default of 1 second is a bit to low).