### PR TITLE
Adds master version for go in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
+os: linux
+dist: xenial
+
 language: go
 
-go:
-  - "1.15.5"
-
-os:
-  - linux
-
-dist: xenial
+jobs:
+  include:
+    - go: "master"
+      env: "GOIMPORTS_CHECK=0"
+    - go: "1.15.5"
+      env: "GOIMPORTS_CHECK=1"
 
 cache:
   directories:
@@ -20,7 +22,7 @@ env:
 
 before_script:
   - set -eo pipefail
-  - go get -u golang.org/x/tools/cmd/goimports
+  - test $GOIMPORTS_CHECK -eq 1 && go get -u golang.org/x/tools/cmd/goimports
 script:
   # We could merge the two commands below for efficiency, but it would give less comprehensive errors
   # Check files syntax and basic formatting
@@ -36,8 +38,8 @@ script:
   # Then check formatting errors
   - checkEmpty "$ERR_FILES"
   # Check advanced files formatting, including imports
-  - ERR_FILES=`find . -name "*.go" -execdir goimports -l '{}' \+`
-  - checkEmpty "$ERR_FILES"
+  - test $GOIMPORTS_CHECK -eq 1 && ERR_FILES=`find . -name "*.go" -execdir goimports -l '{}' \+`
+  - test $GOIMPORTS_CHECK -eq 1 && checkEmpty "$ERR_FILES"
 
   # Run the test suite
   - go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,20 @@ env:
 
 before_script:
   - set -eo pipefail
-  - test $GOIMPORTS_CHECK -eq 1 && go get -u golang.org/x/tools/cmd/goimports
+  - |
+    if test $GOIMPORTS_CHECK -eq 1
+    then
+      go get -u golang.org/x/tools/cmd/goimports
+    fi
 script:
   # We could merge the two commands below for efficiency, but it would give less comprehensive errors
   # Check files syntax and basic formatting
-  - function checkEmpty() {
-      if [ -n "$1" ] ;
+  - |
+    function checkEmpty() {
+      if [ -n "$1" ]
       then
-        echo -e "\nFiles with syntax or formatting errors ($ERR_FILES)\n";
-        return 1;
+        echo -e "\nFiles with syntax or formatting errors ($ERR_FILES)\n"
+        return 1
       fi  
     }
   # If a syntax error occurs, the following command fails
@@ -38,8 +43,12 @@ script:
   # Then check formatting errors
   - checkEmpty "$ERR_FILES"
   # Check advanced files formatting, including imports
-  - test $GOIMPORTS_CHECK -eq 1 && ERR_FILES=`find . -name "*.go" -execdir goimports -l '{}' \+`
-  - test $GOIMPORTS_CHECK -eq 1 && checkEmpty "$ERR_FILES"
+  - |
+    if test $GOIMPORTS_CHECK -eq 1
+    then
+      ERR_FILES=`find . -name "*.go" -execdir goimports -l '{}' \+`
+      checkEmpty "$ERR_FILES"
+    fi
 
   # Run the test suite
   - go test -v ./...


### PR DESCRIPTION
We could also use the `go: stable` version, which should work with `goimports`

Fixes #13 