### PR TITLE
Remove object counter in objects store

### DIFF
--- a/internal/store/objects/store.go
+++ b/internal/store/objects/store.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	crud "github.com/iov-one/cosmos-sdk-crud"
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/iterator"
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"

--- a/internal/store/objects/store.go
+++ b/internal/store/objects/store.go
@@ -19,18 +19,10 @@ func NewStore(cdc codec.Marshaler, db sdk.KVStore) Store {
 	}
 }
 
-type Counter struct {
-	count uint64
-}
-
 // Store builds an object store
 type Store struct {
 	db  sdk.KVStore
 	cdc codec.Marshaler
-	// This has to be a reference in order to persist between calls
-	// Otherwise, if we want to use a simple uint64,
-	// we must switch to pointer receiver and pointer storage in struct (or use it through an interface)
-	//objects *Counter
 }
 
 // Create creates the object in the store
@@ -42,7 +34,6 @@ func (s Store) Create(o crud.Object) error {
 		return fmt.Errorf("%w: primary key %x", crud.ErrAlreadyExists, pk)
 	}
 	err := s.set(pk, o)
-	// s.objects.count++
 	return err
 }
 
@@ -86,7 +77,6 @@ func (s Store) Delete(primaryKey []byte) error {
 		return fmt.Errorf("%w: primary key %x", crud.ErrNotFound, primaryKey)
 	}
 	s.db.Delete(primaryKey)
-	//s.objects.count--
 	return nil
 }
 
@@ -95,11 +85,6 @@ func (s Store) Delete(primaryKey []byte) error {
 func (s Store) GetAllKeysWithIterator(start uint64, end uint64) (types.Iterator, error) {
 	// We could use append but it has to reallocate each time its capacity is reached
 	// Tracking the number of objects on the store is more efficient
-
-	// If the start offset is superior to the number of element, we can skip directly
-	/*if start >= s.objects.count {
-		return iterator.NilIterator{}, nil
-	}*/
 
 	// The start and end arguments of Iterator() are not indexes but byte array boundaries
 	it := s.db.Iterator(nil, nil)

--- a/internal/store/objects/store.go
+++ b/internal/store/objects/store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	crud "github.com/iov-one/cosmos-sdk-crud"
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/iterator"
 	"github.com/iov-one/cosmos-sdk-crud/internal/store/types"
@@ -13,11 +14,9 @@ import (
 
 // NewStore is Store's constructor
 func NewStore(cdc codec.Marshaler, db sdk.KVStore) Store {
-	ctr := Counter{}
 	return Store{
-		db:      db,
-		cdc:     cdc,
-		objects: &ctr,
+		db:  db,
+		cdc: cdc,
 	}
 }
 
@@ -32,7 +31,7 @@ type Store struct {
 	// This has to be a reference in order to persist between calls
 	// Otherwise, if we want to use a simple uint64,
 	// we must switch to pointer receiver and pointer storage in struct (or use it through an interface)
-	objects *Counter
+	//objects *Counter
 }
 
 // Create creates the object in the store
@@ -44,7 +43,7 @@ func (s Store) Create(o crud.Object) error {
 		return fmt.Errorf("%w: primary key %x", crud.ErrAlreadyExists, pk)
 	}
 	err := s.set(pk, o)
-	s.objects.count++
+	// s.objects.count++
 	return err
 }
 
@@ -88,7 +87,7 @@ func (s Store) Delete(primaryKey []byte) error {
 		return fmt.Errorf("%w: primary key %x", crud.ErrNotFound, primaryKey)
 	}
 	s.db.Delete(primaryKey)
-	s.objects.count--
+	//s.objects.count--
 	return nil
 }
 
@@ -99,9 +98,9 @@ func (s Store) GetAllKeysWithIterator(start uint64, end uint64) (types.Iterator,
 	// Tracking the number of objects on the store is more efficient
 
 	// If the start offset is superior to the number of element, we can skip directly
-	if start >= s.objects.count {
+	/*if start >= s.objects.count {
 		return iterator.NilIterator{}, nil
-	}
+	}*/
 
 	// The start and end arguments of Iterator() are not indexes but byte array boundaries
 	it := s.db.Iterator(nil, nil)


### PR DESCRIPTION
The object counter was an optimization in the case we iterate over the objects with a starting offset greater than the total number of objects. It causes issues because an `crud.Store` could be created when the underlying db already has objects in it. Moreover, the optimized case is not a frequent one