### PR TITLE
Adds a primary key for update in order to ban primary key modifications

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -18,6 +18,10 @@ var ErrBadArgument = errors.New("crud: bad argument")
 // might be related to possible state corruption
 var ErrInternal = errors.New("crud: internal error")
 
+// ErrAlteredPrimaryKey is returned when an update is called on an object whose primary key
+// has been altered
+var ErrAlteredPrimaryKey = errors.New("crud: primary key has been altered")
+
 // ErrCursorConsumed is returned in case the cursor used for primary key filtering
 // is not valid anymore because it was consumed
 var ErrCursorConsumed = fmt.Errorf("%w: cursor consumed", ErrBadArgument)

--- a/internal/test/fuzz_test.go
+++ b/internal/test/fuzz_test.go
@@ -10,9 +10,10 @@ import (
 	"net/http"
 	"testing"
 
-	crud "github.com/iov-one/cosmos-sdk-crud"
 	"github.com/lucasjones/reggen"
 	"github.com/tendermint/tendermint/libs/rand"
+
+	crud "github.com/iov-one/cosmos-sdk-crud"
 )
 
 type Config struct {
@@ -196,7 +197,7 @@ func testDelete(t *testing.T, store crud.Store, objects []*TestStarname) {
 func testUpdate(t *testing.T, store crud.Store, objects []*TestStarname) {
 	obj := randomObject(objects)
 	obj.Owner = "S" + obj.Owner[1:]
-	err := store.Update(obj)
+	err := store.Update(obj.PrimaryKey(), obj)
 	CheckNoError(t, err)
 
 	testObj := NewTestStarname("", "", "")

--- a/types.go
+++ b/types.go
@@ -75,14 +75,16 @@ type Store interface {
 	// or in case of marshalling error
 	Create(o Object) error
 	// Read reads to the given object using the primary key
-	// 'o' is expected to be a pointer
+	// 'o' is expected to be a pointer to a valid object
 	// fails in case or error unmarshalling or in case
 	// the object does not exist
 	Read(primaryKey []byte, o Object) error
-	// Update updates the given object
-	// fails if there are errors marshalling
+	// Update updates the given object, the primary key
+	// provided MUST BE the original one, do not just give the current one.
+	// Fails if there are errors marshalling
+	// if the primary key does not match the object primary key
 	// or if the object does not exist
-	Update(o Object) error
+	Update(primaryKey []byte, o Object) error
 	// Delete deletes the object from the crud store
 	// given the primary key, fails if the object with
 	// primary key provided does not exist

--- a/types/store_test.go
+++ b/types/store_test.go
@@ -36,7 +36,7 @@ func TestStore(t *testing.T) {
 	// test update
 	update := obj
 	update.TestSecondaryKeyB = []byte("test-update")
-	err = s.Update(update)
+	err = s.Update(obj.PrimaryKey(), update)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,6 +91,19 @@ func TestStore(t *testing.T) {
 		if !errors.Is(err, crud.ErrAlreadyExists) {
 			t.Fatal("Object should be a duplicate")
 		}
+	})
+	t.Run("update/pk modification", func(t *testing.T) {
+		obj := test.NewRandomObject()
+		pk := obj.PrimaryKey()
+		if err = s.Create(obj); err != nil {
+			t.Fatal("Unexpected error :", err)
+		}
+		obj.TestPrimaryKey = []byte("Modified-pk")
+
+		if err = s.Update(pk, obj); !errors.Is(err, crud.ErrAlteredPrimaryKey) {
+			t.Fatal("Update should not allow primary key modification")
+		}
+
 	})
 	t.Run("delete/existing", func(t *testing.T) {
 		err = s.Delete(test.NewDeterministicObject().PrimaryKey())


### PR DESCRIPTION
Modifying part of or the entire primary key of an object was an undefined behavior: depending on what was present on the store it could fail with an `ErrNotFound` error or silently overwrite an existing object in the store. This new version ensures primary key modification is consistently rejected.

This pull request fixes #19 and changes this package interface, so needs a new version tag.