### PR TITLE
Do our best to enforce primary key immutability

### DIFF
--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -1,0 +1,128 @@
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"reflect"
+
+	crud "github.com/iov-one/cosmos-sdk-crud"
+)
+
+func CheckPrimaryKeyImmutability(object crud.Object) {
+
+	pk := append([]byte{}, object.PrimaryKey()...)
+
+	reflectedObj := reflect.ValueOf(object).Elem()
+	mutateAllExportedFields(&reflectedObj)
+
+	pkAfter := reflectedObj.FieldByName("PrimaryKey").Call(nil)[0].Bytes()
+
+	if !bytes.Equal(pk, pkAfter) {
+		panic(fmt.Errorf("primary key of type %T implementing crud.Object is not immutable", object))
+	}
+}
+
+func mutateAllExportedFields(obj *reflect.Value) {
+
+	// This object is not exported, skip it
+	if !obj.CanSet() {
+		return
+	}
+
+	switch obj.Type().Kind() {
+	case reflect.String:
+		fallthrough
+	case reflect.Slice:
+		fallthrough
+	case reflect.Array:
+		mutateSlice(obj)
+
+	case reflect.Uint64:
+		fallthrough
+	case reflect.Uintptr:
+		fallthrough
+	case reflect.Uint:
+		fallthrough
+	case reflect.Uint32:
+		fallthrough
+	case reflect.Uint16:
+		fallthrough
+	case reflect.Uint8:
+		obj.SetUint(randomUint())
+
+	case reflect.Int:
+		fallthrough
+	case reflect.Int64:
+		fallthrough
+	case reflect.Int32:
+		fallthrough
+	case reflect.Int16:
+		fallthrough
+	case reflect.Int8:
+		obj.SetInt(int64(randomUint()))
+
+	case reflect.Float64:
+		fallthrough
+	case reflect.Float32:
+		obj.SetFloat(randomFloat())
+
+	case reflect.Bool:
+		obj.SetBool(randomBool())
+
+	case reflect.Complex128:
+		fallthrough
+	case reflect.Complex64:
+		obj.SetComplex(randomComplex())
+
+	case reflect.Map:
+		mutateMap(obj)
+
+	case reflect.Func:
+		//TODO: use functions
+	case reflect.Ptr:
+		fallthrough
+	case reflect.UnsafePointer:
+		//TODO: mutate pointers
+
+	case reflect.Interface:
+		fallthrough
+	case reflect.Struct:
+		for i := 0; i < obj.NumField(); i++ {
+			field := obj.Field(i)
+			mutateAllExportedFields(&field)
+		}
+	}
+}
+
+func randomFloat() float64 {
+	return rand.Float64()
+}
+
+func randomUint() uint64 {
+	return rand.Uint64()
+}
+
+func randomBool() bool {
+	return rand.Intn(2) == 1
+}
+
+func randomComplex() complex128 {
+	return complex(randomFloat(), randomFloat())
+}
+
+func mutateMap(obj *reflect.Value) {
+	iter := obj.MapRange()
+	for iter.Next() {
+		val := iter.Value()
+		mutateAllExportedFields(&val)
+		obj.SetMapIndex(iter.Key(), val)
+	}
+}
+
+func mutateSlice(obj *reflect.Value) {
+	for i := 0; i < obj.Len(); i++ {
+		val := obj.Slice(i, i+1)
+		mutateAllExportedFields(&val)
+	}
+}

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -16,7 +16,7 @@ func CheckPrimaryKeyImmutability(object crud.Object) {
 	reflectedObj := reflect.ValueOf(object).Elem()
 	mutateAllExportedFields(&reflectedObj)
 
-	pkAfter := reflectedObj.FieldByName("PrimaryKey").Call(nil)[0].Bytes()
+	pkAfter := reflectedObj.MethodByName("PrimaryKey").Call(nil)[0].Bytes()
 
 	if !bytes.Equal(pk, pkAfter) {
 		panic(fmt.Errorf("primary key of type %T implementing crud.Object is not immutable", object))

--- a/types.go
+++ b/types.go
@@ -26,10 +26,12 @@ type SecondaryKey struct {
 }
 
 // Object defines a structure that can be saved in the crud store
+// It has an immutable primary key and can have multiple indexed attributes, called secondary keys
 type Object interface {
 	codec.ProtoMarshaler
 
 	// PrimaryKey is the unique id that identifies the object
+	// It MUST be immutable in order to have working update functionality
 	PrimaryKey() []byte
 	// SecondaryKeys is an array containing the secondary keys
 	// used to map the object


### PR DESCRIPTION
This PR introduces detailed comments in the `crud.Object` documentation about primary key immutability.
It also provides a function `testutil.CheckPrimaryKeyImmutability` to check that a `crud.Object` implementation does not rely on exported fields for there primary key (and thus enforcing it to be immutable).

Currently, the `CheckPrimaryKeyImmutability` function does not check for changes via exported methods or functions.

This closes #19 and #20 